### PR TITLE
UnregisterSubscriptionの実装

### DIFF
--- a/apiServer/models/user_subscription.go
+++ b/apiServer/models/user_subscription.go
@@ -69,3 +69,14 @@ func (u *UserSubscription) Find(userSubscriptionID string) (*UserSubscription, e
 	}
 	return &userSubscription, nil
 }
+
+// Unregister 特定のuser_subscriptionを削除する
+func (u *UserSubscription) Unregister(userID string, userSubscriptionID string) (*UserSubscription, error) {
+	var userSubscription UserSubscription
+	findUserSubscriptionQuery := DB.Where("user_id = ? and user_subscription_id = ?", userID, userSubscriptionID)
+	if err := findUserSubscriptionQuery.First(&userSubscription).Error; err != nil {
+		return nil, err
+	}
+	findUserSubscriptionQuery.Delete(&userSubscription)
+	return &userSubscription, nil
+}

--- a/apiServer/service/subscription.go
+++ b/apiServer/service/subscription.go
@@ -92,6 +92,10 @@ func (SubscriptionServiceImpl) UpdateSubscription(ctx context.Context, req *subs
 }
 
 // UnregisterSubscription 登録済みのサブスクをリストから削除する
-func (SubscriptionServiceImpl) UnregisterSubscription(context.Context, *subscription.UnregisterSubscriptionRequest) (*subscription.UnregisterSubscriptionResponse, error) {
-	return &subscription.UnregisterSubscriptionResponse{}, nil
+func (SubscriptionServiceImpl) UnregisterSubscription(ctx context.Context, req *subscription.UnregisterSubscriptionRequest) (*subscription.UnregisterSubscriptionResponse, error) {
+	usub, err := new(models.UserSubscription).Unregister(req.UserId, req.UserSubscriptionId)
+	if err != nil {
+		return nil, responses.NotFoundError(err.Error())
+	}
+	return &subscription.UnregisterSubscriptionResponse{UserSubscriptionId: usub.UserSubscriptionID}, nil
 }


### PR DESCRIPTION
close #17  

## やったこと

- UnregisterSubscriptionの実装

## 補足事項
単に`DB.Where(条件句).Delete()`だと、データが存在しなくてもエラーが出ないので、一回Findかけてます（冗長な気もするので代案あれば教えていただけると...）

あと一応確認だけど、物理削除でいいんだよね？？？
